### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -88,13 +88,39 @@ export function trackLinkClick(
 function getLinkText(href: string): string {
   if (href.startsWith("mailto:")) return "Email";
   if (href.startsWith("tel:")) return "Phone";
-  if (href.includes("checkfront")) return "Checkfront";
-  if (href.includes("facebook")) return "Facebook";
-  if (href.includes("instagram")) return "Instagram";
-  if (href.includes("linkedin")) return "LinkedIn";
-  if (href.includes("twitter.com") || href.includes("x.com")) return "Twitter/X";
-  if (href.includes("youtube")) return "YouTube";
-  if (href.includes("whatsapp")) return "WhatsApp";
-  if (href.includes("google.com/maps") || href.includes("goo.gl/maps")) return "Directions";
+
+  try {
+    const parsed = new URL(href, isBrowser() ? window.location.origin : "http://localhost");
+    const host = parsed.hostname.toLowerCase();
+
+    if (host === "checkfront.com" || host.endsWith(".checkfront.com")) return "Checkfront";
+    if (host === "facebook.com" || host.endsWith(".facebook.com")) return "Facebook";
+    if (host === "instagram.com" || host.endsWith(".instagram.com")) return "Instagram";
+    if (host === "linkedin.com" || host.endsWith(".linkedin.com")) return "LinkedIn";
+    if (
+      host === "twitter.com" ||
+      host.endsWith(".twitter.com") ||
+      host === "x.com" ||
+      host.endsWith(".x.com")
+    ) {
+      return "Twitter/X";
+    }
+    if (host === "youtube.com" || host.endsWith(".youtube.com") || host === "youtu.be") return "YouTube";
+    if (host === "whatsapp.com" || host.endsWith(".whatsapp.com") || host === "wa.me") return "WhatsApp";
+    if (host === "google.com" || host.endsWith(".google.com") || host === "goo.gl") {
+      if (parsed.pathname.startsWith("/maps")) return "Directions";
+    }
+  } catch {
+    // Fallback for malformed/non-URL strings
+    if (href.includes("checkfront")) return "Checkfront";
+    if (href.includes("facebook")) return "Facebook";
+    if (href.includes("instagram")) return "Instagram";
+    if (href.includes("linkedin")) return "LinkedIn";
+    if (href.includes("twitter.com") || href.includes("x.com")) return "Twitter/X";
+    if (href.includes("youtube")) return "YouTube";
+    if (href.includes("whatsapp")) return "WhatsApp";
+    if (href.includes("google.com/maps") || href.includes("goo.gl/maps")) return "Directions";
+  }
+
   return "Link";
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -111,15 +111,8 @@ function getLinkText(href: string): string {
       if (parsed.pathname.startsWith("/maps")) return "Directions";
     }
   } catch {
-    // Fallback for malformed/non-URL strings
-    if (href.includes("checkfront")) return "Checkfront";
-    if (href.includes("facebook")) return "Facebook";
-    if (href.includes("instagram")) return "Instagram";
-    if (href.includes("linkedin")) return "LinkedIn";
-    if (href.includes("twitter.com") || href.includes("x.com")) return "Twitter/X";
-    if (href.includes("youtube")) return "YouTube";
-    if (href.includes("whatsapp")) return "WhatsApp";
-    if (href.includes("google.com/maps") || href.includes("goo.gl/maps")) return "Directions";
+    // Fallback for malformed/non-URL strings.
+    // Avoid substring-based domain matching here; only parsed URL host checks are trusted.
   }
 
   return "Link";


### PR DESCRIPTION
Potential fix for [https://github.com/spizeck/seasaba-web/security/code-scanning/2](https://github.com/spizeck/seasaba-web/security/code-scanning/2)

Use URL parsing and hostname-aware matching instead of substring matching for domain-based checks.

Best fix (without changing intended behavior): in `lib/analytics.ts`, update `getLinkText` to:
- Keep protocol checks (`mailto:`, `tel:`) as-is.
- Parse `href` with `new URL(href, window.location.origin)` (fallback base for relative URLs in browser).
- Extract `hostname` safely (lowercased).
- Match social/directions services against exact host or subdomain patterns (`host === "x.com" || host.endsWith(".x.com")`, etc.).
- If parsing fails, fall back to conservative substring checks (preserves resilience for malformed strings).

This keeps functionality while removing the unsafe `includes("x.com")` pattern and similar host-matching fragility.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Improve link classification in analytics by using URL parsing and hostname-based checks instead of raw substring matching for external domains.

Enhancements:
- Use URL parsing with hostname-aware matching to classify external links (social, maps, messaging) in analytics.
- Add a conservative fallback to legacy substring matching when URL parsing fails to maintain resilience for malformed href values.