### PR TITLE
Enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Adds weekly npm Dependabot updates for the root Next.js app so dependency update PRs are opened automatically.

This is intentionally limited to 10 open Dependabot PRs at a time to avoid flooding the repo.

## Summary by Sourcery

Build:
- Add Dependabot configuration file to automate weekly npm dependency updates with a limit on concurrent open PRs.