### PR TITLE
Fix/contact form blur shift

### DIFF
--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -163,11 +163,9 @@ export function ContactForm({ initialInterest }: ContactFormProps) {
             className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             placeholder="Your full name"
           />
-          {touched.name && errors.name && (
-            <p id="name-error" className="text-xs text-destructive">
-              {errors.name}
-            </p>
-          )}
+          <p id="name-error" className={`min-h-5 text-xs text-destructive${touched.name && errors.name ? "" : " invisible"}`}>
+            {touched.name && errors.name ? errors.name : "\u00A0"}
+          </p>
         </div>
 
         <div className="space-y-2">
@@ -186,11 +184,9 @@ export function ContactForm({ initialInterest }: ContactFormProps) {
             className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             placeholder="you@example.com"
           />
-          {touched.email && errors.email && (
-            <p id="email-error" className="text-xs text-destructive">
-              {errors.email}
-            </p>
-          )}
+          <p id="email-error" className={`min-h-5 text-xs text-destructive${touched.email && errors.email ? "" : " invisible"}`}>
+            {touched.email && errors.email ? errors.email : "\u00A0"}
+          </p>
         </div>
       </div>
 
@@ -305,11 +301,9 @@ export function ContactForm({ initialInterest }: ContactFormProps) {
             ))}
           </optgroup>
         </select>
-        {touched.inquiryType && errors.inquiryType && (
-          <p id="inquiry-type-error" className="text-xs text-destructive">
-            {errors.inquiryType}
-          </p>
-        )}
+        <p id="inquiry-type-error" className={`min-h-5 text-xs text-destructive${touched.inquiryType && errors.inquiryType ? "" : " invisible"}`}>
+          {touched.inquiryType && errors.inquiryType ? errors.inquiryType : "\u00A0"}
+        </p>
       </div>
 
       <div className="space-y-2">
@@ -356,11 +350,9 @@ export function ContactForm({ initialInterest }: ContactFormProps) {
           className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           placeholder="Tell us about your plans, questions, or anything we should know."
         />
-        {touched.message && errors.message && (
-          <p id="message-error" className="text-xs text-destructive">
-            {errors.message}
-          </p>
-        )}
+        <p id="message-error" className={`min-h-5 text-xs text-destructive${touched.message && errors.message ? "" : " invisible"}`}>
+          {touched.message && errors.message ? errors.message : "\u00A0"}
+        </p>
       </div>
 
       <div className="flex flex-col gap-3 pt-2 sm:flex-row">

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -84,6 +84,7 @@ The complete `npm run test:ci` command passed locally: 65 browser checks passed 
 
 - Connected dive-log filter labels to unique select IDs, improving screen-reader labeling and user-focused test queries.
 - Restored the hiking section anchor so `/hiking-on-saba` lands on the existing hiking content.
+- Stabilized contact-form validation layout: error messages reserve space with `min-h-5` and `invisible` instead of being conditionally removed from the DOM, preventing the submit button from shifting when blur clears a validation error during a mouse click.
 
 ## Remaining gaps and gate before yacht development
 
@@ -95,7 +96,7 @@ The complete `npm run test:ci` command passed locally: 65 browser checks passed 
 6. Add a seeded Firestore emulator-backed browser dive-log flow when rules are available. Current data and UI integration tests cover the flow in-process; browser smoke proves the route renders but does not prove live data availability.
 7. Before implementing yachts, specify their visitor journeys and data ownership. Add acceptance scenarios for the proposed behavior while keeping these current flows green. Add authentication/session/API tests only if those capabilities are actually introduced.
 
-Contact recovery currently clears error text on blur, which can shift the submit button during a mouse click after correcting an invalid address. The browser recovery test tabs out of the field before submitting; direct mouse correction deserves a follow-up UX regression fix.
+Contact recovery reserves space for validation errors (`min-h-5` with `invisible`) so correcting an invalid address does not shift the submit button during a mouse click. The browser recovery tests cover both tabbed submission and direct mouse correction without Tab or artificial waits, verifying exactly one handoff fires across all three browser projects.
 
 Future regression fixes should add a failing behavior test at the lowest useful layer first. Keep full customer journeys in Playwright and boundary/error combinations in Vitest. Do not substitute broad snapshots for behavior assertions.
 

--- a/tests/e2e/customer-flows.spec.ts
+++ b/tests/e2e/customer-flows.spec.ts
@@ -36,6 +36,45 @@ test("course inquiry validates then prepares a WhatsApp handoff", async ({ page 
   expect(new URL(href).searchParams.get("text")).toContain("Test Guest");
   expect(new URL(href).searchParams.get("text")).toContain("Try Scuba");
 });
+test("correcting an invalid email and clicking submit without Tab produces exactly one handoff", async ({ page }) => {
+  // Track every window.open call to verify exactly one handoff fires.
+  await page.addInitScript(() => {
+    const calls: string[] = [];
+    window.open = (url) => { calls.push(String(url)); return null; };
+    (window as unknown as { handoffCalls: string[] }).handoffCalls = calls;
+  });
+  await page.goto("/contact?interest=try-scuba");
+
+  // Fill all required fields except email.
+  await page.getByRole("textbox", { name: /^Name/ }).fill("Blur Test Guest");
+  await page.getByRole("textbox", { name: /^Email/ }).fill("not-an-email");
+  // Inquiry is pre-filled by ?interest=try-scuba; message is pre-filled by the component.
+
+  // Submit to trigger validation -- should fail on invalid email.
+  await page.getByRole("button", { name: "Send inquiry by WhatsApp" }).click();
+  await expect(page.getByText("Please enter a valid email address.")).toBeVisible();
+
+  // Correct the email directly, then click submit WITHOUT pressing Tab first.
+  // Before the fix, clearing the error on blur could shift the button and cause
+  // the click to miss or fire twice.
+  await page.getByRole("textbox", { name: /^Email/ }).fill("guest@example.test");
+  await page.getByRole("button", { name: "Send inquiry by WhatsApp" }).click();
+
+  // Wait for the handoff to complete.
+  await expect.poll(() => page.evaluate(() =>
+    (window as unknown as { handoffCalls: string[] }).handoffCalls.length
+  )).toBeGreaterThan(0);
+
+  // Verify exactly one handoff occurred and it contains the corrected data.
+  const calls = await page.evaluate(() =>
+    (window as unknown as { handoffCalls: string[] }).handoffCalls
+  );
+  expect(calls).toHaveLength(1);
+  const url = new URL(calls[0]);
+  expect(url.origin + url.pathname).toBe("https://wa.me/5994162246");
+  expect(url.searchParams.get("text")).toContain("Blur Test Guest");
+  expect(url.searchParams.get("text")).toContain("Try Scuba");
+});
 test("mobile menu opens, navigates, and closes", async ({ page, isMobile }) => {
   test.skip(!isMobile, "mobile navigation only");
   await page.goto("/");


### PR DESCRIPTION
## Summary by Sourcery

Keep contact-form validation layout stable while validating reliable direct mouse recovery and submission.

Bug Fixes:
- Prevent contact-form validation messages from shifting the submit button during blur and correction, ensuring direct mouse submission triggers exactly one WhatsApp handoff.

Documentation:
- Document the stabilized contact-form validation layout and expanded browser recovery coverage.

Tests:
- Add an end-to-end test covering correction of an invalid email followed by direct mouse submission without tabbing.