### PR TITLE
fix(security): update undici 7.29.0 -> 7.29.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15433,9 +15433,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Resolves all four high-severity Dependabot alerts on master:

- CVE-2026-84933  Set-Cookie header leaked via shared-cache mode
- CVE-2026-85008  Unsafe HTTP methods cached by cache interceptor
- CVE-2026-84890  Decompression bomb (unbounded output size)
- CVE-2026-84947  Dump interceptor double-completion on chunked

undici 7.29.0 was a transitive dependency via shadcn@4.19.0 (declares ^7.27.2). The semver range already permits 7.29.1, so this is a lockfile-only change (3 insertions, 3 deletions).

npm audit: 0 vulnerabilities across 1085 packages.
Full test suite passes: 72 Vitest, 65 Playwright, lint, typecheck, build.

Generated with [Devin](https://devin.ai)

## Summary by Sourcery

Bug Fixes:
- Update the locked Undici dependency to 7.29.1 to address four high-severity security vulnerabilities.